### PR TITLE
Update the "Representation By Year" query

### DIFF
--- a/components/BarChartYears/index.tsx
+++ b/components/BarChartYears/index.tsx
@@ -59,15 +59,14 @@ interface BarChartProps {
 function BarChartYears({ data }: BarChartProps) {
     if (!data) return <div>Loading...</div>
 
-    // Filter out cases prior than 2007
-    const filtered = data.filter((a) => a.year > 2007)
-    const groupedByYear = groupBy(filtered)((a) => a.year.toString())
+    const groupedByYear = groupBy(data)((a) => a.year.toString())
     const totals = getTotals(groupedByYear)
 
-    const retained = filtered
+    // Sum the number of cases
+    const retained = data
         .filter((a) => a.attorney_type === 'Retained')
         .reduce((acc, curr) => acc + curr.case_count, 0)
-    const appointed = filtered
+    const appointed = data
         .filter((a) => a.attorney_type === 'Court Appointed')
         .reduce((acc, curr) => acc + curr.case_count, 0)
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -35,6 +35,13 @@ SELECT
   DateTimePart("year", c.earliest_charge_date) AS year,
   COUNT(1) AS case_count
  FROM c
+ WHERE
+  IS_DEFINED(c.has_evidence_of_representation)
+  AND DateTimePart("year", c.earliest_charge_date) > 2007
+  AND (
+       c.attorney_type = "Court Appointed"
+    OR c.attorney_type = "Retained"
+  )
  GROUP BY
   DateTimePart("year", c.earliest_charge_date),
   c.has_evidence_of_representation,


### PR DESCRIPTION
I went ahead and uploaded the entire 200+ MB file of `nested_cases.json` and some of the data didn't have `evidence_of_representation`. We likely need to do some additional cleaning on that data, but in the mean time I added some clauses to the sql that will filter out the problematic records.