### PR TITLE
Add chart that shows attorney ratios per charge category

### DIFF
--- a/components/CounselPerChargeCategoryBarChart/CounselPerChargeCategoryBarChart.tsx
+++ b/components/CounselPerChargeCategoryBarChart/CounselPerChargeCategoryBarChart.tsx
@@ -1,0 +1,209 @@
+import React, { ReactNode } from 'react'
+import z from 'zod'
+import useSWR from 'swr'
+import styled from 'styled-components'
+
+import {
+    BarChart,
+    Bar,
+    XAxis,
+    YAxis,
+    ResponsiveContainer,
+    Legend,
+    CartesianGrid,
+    Tooltip,
+} from 'recharts'
+import { Props as LegendProps } from 'recharts/types/component/Legend'
+import { Props } from 'recharts/types/component/Legend'
+
+import {
+    LegendWrapper,
+    LegendBox,
+    LegendTitle,
+    LegendSpan,
+    LegendColorBlock,
+    LegendSampleSize,
+    LegendSampleSizeTitle,
+} from '../LegendUI'
+import { stackedGraphColors } from '../../lib/colors'
+import { H4 } from '../Typography/Headings'
+import { ErrorComponent } from '../ErrorComponent'
+import { mapWithIndex } from '../../lib/record'
+import { groupBy } from '../../lib/array'
+import fetcher from '../../lib/fetcher'
+
+const ChartTitle = styled(H4)`
+    text-align: center;
+`
+
+const SECRET = process.env.NEXT_PUBLIC_COSMOSDB_SECRET
+
+const QUERY = `
+SELECT a.charge_category, a.attorney_type, COUNT(a) AS count
+  FROM (
+    SELECT c.attorney_type, charge["charge_category"] AS charge_category FROM c
+    JOIN charge IN c["charges"]
+    WHERE
+        charge["charge_category"] != null AND
+        (c.attorney_type = "Retained" OR
+        c.attorney_type = "Court Appointed")
+  ) a
+  GROUP BY a.attorney_type, a.charge_category
+`
+
+const schema = z.array(
+    z.object({
+        charge_category: z.string(),
+        attorney_type: z.string(),
+        count: z.number(),
+    })
+)
+
+export function CounselPerChargeCategoryBarChart() {
+    const { data, error, isLoading } = useSWR(
+        `/api/cosmos?secret=${SECRET}&sql=${QUERY}&container=clean-cases&db=cases-json-db`,
+        fetcher
+    )
+
+    if (isLoading) {
+        return <>Loading...</>
+    }
+
+    if (error) {
+        return <ErrorComponent />
+    }
+
+    const parsed = schema.safeParse(data?.data)
+
+    if (!parsed.success) {
+        console.log(parsed.error.format())
+
+        return <>There was an parsing the data</>
+    }
+
+    const grouped = groupBy(parsed.data)((a) => a.charge_category)
+
+    const mapped = mapWithIndex(grouped, (category, charges) => {
+        const [a, b] = charges
+
+        const retained = a.attorney_type === 'Retained' ? a.count : b.count
+        const appointed = a.attorney_type === 'Retained' ? b.count : a.count
+
+        return {
+            category,
+            retained,
+            appointed,
+            total: a.count + b.count,
+        }
+    })
+
+    // const categories = Object.keys(grouped)
+    const records = Object.values(mapped)
+
+    // Sum the number of cases
+    const retained = records.reduce((acc, curr) => acc + curr.retained, 0)
+    const appointed = records.reduce((acc, curr) => acc + curr.appointed, 0)
+
+    return (
+        <>
+            <ChartTitle>
+                Cases per Attorney Type Grouped by Charge Category
+            </ChartTitle>
+
+            <ResponsiveContainer
+                width="100%"
+                height="100%"
+                minHeight={450}
+                className={'stacked-bar-chart stacked-bar-chart-bottom'}
+            >
+                <BarChart
+                    data={records}
+                    margin={{
+                        top: 20,
+                        right: 30,
+                        left: 20,
+                        bottom: 5,
+                    }}
+                >
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis dataKey="category" />
+                    <YAxis />
+                    <Tooltip />
+                    <Legend
+                        // @ts-ignore: Not a relevant props error
+                        content={(props: LegendProps) =>
+                            renderLegend(props, 'Type of lawyer', {
+                                retained,
+                                appointed,
+                            })
+                        }
+                    />
+                    <Bar
+                        dataKey="appointed"
+                        stackId="a"
+                        fill={stackedGraphColors[1]}
+                    />
+                    <Bar
+                        dataKey="retained"
+                        stackId="b"
+                        fill={stackedGraphColors[5]}
+                    />
+                </BarChart>
+            </ResponsiveContainer>
+        </>
+    )
+}
+
+const LegendBoxRow = styled(LegendBox)`
+    max-width: 100%;
+`
+
+const LegendItems = styled.div`
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 1rem;
+`
+
+const renderLegend = (
+    props: Props,
+    title: string,
+    sums: {
+        appointed: number
+        retained: number
+    }
+): ReactNode => {
+    return (
+        <LegendWrapper>
+            <LegendSampleSize>
+                <LegendSampleSizeTitle>Sample size</LegendSampleSizeTitle>
+                <div>
+                    <small>
+                        Retained: {sums.retained} cases
+                        <br />
+                        Court Appointed: {sums.appointed} cases
+                        <br />
+                        Total: {sums.appointed + sums.retained}
+                    </small>
+                </div>
+            </LegendSampleSize>
+            <LegendBoxRow>
+                <LegendTitle>
+                    <strong>{title}</strong>
+                </LegendTitle>
+                <LegendItems>
+                    {[...(props.payload || [])].map((entry, index) => (
+                        <LegendSpan key={`item-${index}`}>
+                            <LegendColorBlock
+                                style={{
+                                    backgroundColor: entry.color,
+                                }}
+                            />
+                            {entry.value}
+                        </LegendSpan>
+                    ))}
+                </LegendItems>
+            </LegendBoxRow>
+        </LegendWrapper>
+    )
+}

--- a/components/CounselPerChargeCategoryBarChart/CounselPerChargeCategoryBarChart.tsx
+++ b/components/CounselPerChargeCategoryBarChart/CounselPerChargeCategoryBarChart.tsx
@@ -1,4 +1,3 @@
-import React, { ReactNode } from 'react'
 import z from 'zod'
 import useSWR from 'swr'
 import styled from 'styled-components'
@@ -14,23 +13,15 @@ import {
     Tooltip,
 } from 'recharts'
 import { Props as LegendProps } from 'recharts/types/component/Legend'
-import { Props } from 'recharts/types/component/Legend'
 
-import {
-    LegendWrapper,
-    LegendBox,
-    LegendTitle,
-    LegendSpan,
-    LegendColorBlock,
-    LegendSampleSize,
-    LegendSampleSizeTitle,
-} from '../LegendUI'
 import { stackedGraphColors } from '../../lib/colors'
 import { H4 } from '../Typography/Headings'
 import { ErrorComponent } from '../ErrorComponent'
 import { mapWithIndex } from '../../lib/record'
 import { groupBy } from '../../lib/array'
 import fetcher from '../../lib/fetcher'
+
+import { renderLegend } from './Legend'
 
 const ChartTitle = styled(H4)`
     text-align: center;
@@ -151,59 +142,5 @@ export function CounselPerChargeCategoryBarChart() {
                 </BarChart>
             </ResponsiveContainer>
         </>
-    )
-}
-
-const LegendBoxRow = styled(LegendBox)`
-    max-width: 100%;
-`
-
-const LegendItems = styled.div`
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    gap: 1rem;
-`
-
-const renderLegend = (
-    props: Props,
-    title: string,
-    sums: {
-        appointed: number
-        retained: number
-    }
-): ReactNode => {
-    return (
-        <LegendWrapper>
-            <LegendSampleSize>
-                <LegendSampleSizeTitle>Sample size</LegendSampleSizeTitle>
-                <div>
-                    <small>
-                        Retained: {sums.retained} cases
-                        <br />
-                        Court Appointed: {sums.appointed} cases
-                        <br />
-                        Total: {sums.appointed + sums.retained}
-                    </small>
-                </div>
-            </LegendSampleSize>
-            <LegendBoxRow>
-                <LegendTitle>
-                    <strong>{title}</strong>
-                </LegendTitle>
-                <LegendItems>
-                    {[...(props.payload || [])].map((entry, index) => (
-                        <LegendSpan key={`item-${index}`}>
-                            <LegendColorBlock
-                                style={{
-                                    backgroundColor: entry.color,
-                                }}
-                            />
-                            {entry.value}
-                        </LegendSpan>
-                    ))}
-                </LegendItems>
-            </LegendBoxRow>
-        </LegendWrapper>
     )
 }

--- a/components/CounselPerChargeCategoryBarChart/Legend.tsx
+++ b/components/CounselPerChargeCategoryBarChart/Legend.tsx
@@ -1,0 +1,68 @@
+import { ReactNode } from 'react'
+import styled from 'styled-components'
+
+import { Props } from 'recharts/types/component/Legend'
+
+import {
+    LegendWrapper,
+    LegendBox,
+    LegendTitle,
+    LegendSpan,
+    LegendColorBlock,
+    LegendSampleSize,
+    LegendSampleSizeTitle,
+} from '../LegendUI'
+
+const LegendBoxRow = styled(LegendBox)`
+    max-width: 100%;
+`
+
+const LegendItems = styled.div`
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 1rem;
+`
+
+export const renderLegend = (
+    props: Props,
+    title: string,
+    sums: {
+        appointed: number
+        retained: number
+    }
+): ReactNode => {
+    return (
+        <LegendWrapper>
+            <LegendSampleSize>
+                <LegendSampleSizeTitle>Sample size</LegendSampleSizeTitle>
+                <div>
+                    <small>
+                        Retained: {sums.retained} cases
+                        <br />
+                        Court Appointed: {sums.appointed} cases
+                        <br />
+                        Total: {sums.appointed + sums.retained}
+                    </small>
+                </div>
+            </LegendSampleSize>
+            <LegendBoxRow>
+                <LegendTitle>
+                    <strong>{title}</strong>
+                </LegendTitle>
+                <LegendItems>
+                    {[...(props.payload || [])].map((entry, index) => (
+                        <LegendSpan key={`item-${index}`}>
+                            <LegendColorBlock
+                                style={{
+                                    backgroundColor: entry.color,
+                                }}
+                            />
+                            {entry.value}
+                        </LegendSpan>
+                    ))}
+                </LegendItems>
+            </LegendBoxRow>
+        </LegendWrapper>
+    )
+}

--- a/components/CounselPerChargeCategoryBarChart/index.tsx
+++ b/components/CounselPerChargeCategoryBarChart/index.tsx
@@ -1,0 +1,155 @@
+import z from 'zod'
+import useSWR from 'swr'
+import styled from 'styled-components'
+
+import {
+    BarChart,
+    Bar,
+    XAxis,
+    YAxis,
+    ResponsiveContainer,
+    Legend,
+    CartesianGrid,
+    Tooltip,
+} from 'recharts'
+import { Props as LegendProps } from 'recharts/types/component/Legend'
+
+import { colors, stackedGraphColors } from '../../lib/colors'
+import { H4 } from '../Typography/Headings'
+import { ErrorComponent } from '../ErrorComponent'
+import { mapWithIndex } from '../../lib/record'
+import { groupBy } from '../../lib/array'
+import fetcher from '../../lib/fetcher'
+
+import { renderLegend } from './Legend'
+import useMediaQuery from '../../lib/hooks/useMediaQuery'
+
+const ChartTitle = styled(H4)`
+    text-align: center;
+`
+
+const SECRET = process.env.NEXT_PUBLIC_COSMOSDB_SECRET
+
+const QUERY = `
+SELECT a.charge_category, a.attorney_type, COUNT(a) AS count
+  FROM (
+    SELECT c.attorney_type, charge["charge_category"] AS charge_category FROM c
+    JOIN charge IN c["charges"]
+    WHERE
+        charge["charge_category"] != null AND
+        (c.attorney_type = "Retained" OR
+        c.attorney_type = "Court Appointed")
+  ) a
+  GROUP BY a.attorney_type, a.charge_category
+`
+
+const schema = z.array(
+    z.object({
+        charge_category: z.string(),
+        attorney_type: z.string(),
+        count: z.number(),
+    })
+)
+
+const CounselBarChart = () => {
+    const { data, error, isLoading } = useSWR(
+        `/api/cosmos?secret=${SECRET}&sql=${QUERY}&container=clean-cases&db=cases-json-db`,
+        fetcher
+    )
+    const isLg = useMediaQuery('lg')
+
+    if (isLoading) {
+        return <>Loading...</>
+    }
+
+    if (error) {
+        return <ErrorComponent />
+    }
+
+    const parsed = schema.safeParse(data?.data)
+
+    if (!parsed.success) {
+        console.error(parsed.error.format())
+
+        return <>There was an parsing the data</>
+    }
+
+    const grouped = groupBy(parsed.data)((a) => a.charge_category)
+
+    const mapped = mapWithIndex(grouped, (category, charges) => {
+        const [a, b] = charges
+
+        const retained = a.attorney_type === 'Retained' ? a.count : b.count
+        const appointed = a.attorney_type === 'Retained' ? b.count : a.count
+
+        return {
+            category,
+            retained,
+            appointed,
+            total: a.count + b.count,
+        }
+    })
+
+    // const categories = Object.keys(grouped)
+    const records = Object.values(mapped)
+
+    // Sum the number of cases
+    const retained = records.reduce((acc, curr) => acc + curr.retained, 0)
+    const appointed = records.reduce((acc, curr) => acc + curr.appointed, 0)
+
+    return (
+        <>
+            <ChartTitle>
+                Cases per Attorney Type Grouped by Charge Category
+            </ChartTitle>
+
+            <ResponsiveContainer
+                width={'100%'}
+                height="100%"
+                minHeight={isLg ? 600 : '100vh'}
+                className="recharts-wrapper"
+            >
+                <BarChart
+                    maxBarSize={120}
+                    barSize={isLg ? 35 : 30}
+                    barCategoryGap={isLg ? 35 : 10}
+                    barGap={0}
+                    data={records}
+                    margin={{
+                        top: 20,
+                        right: 30,
+                        left: 20,
+                        bottom: 5,
+                    }}
+                    layout="vertical"
+                >
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <YAxis dataKey="category" type="category" fontSize={18} />
+                    <XAxis type="number" />
+                    <Tooltip />
+                    <Legend
+                        // @ts-ignore: Not a relevant props error
+                        content={(props: LegendProps) =>
+                            renderLegend(props, 'Type of lawyer', {
+                                retained,
+                                appointed,
+                            })
+                        }
+                    />
+                    <Bar
+                        dataKey="appointed"
+                        stackId="a"
+                        fill={colors.openAustinOrange}
+                    />
+                    <Bar
+                        dataKey="retained"
+                        stackId="b"
+                        fill={colors.violet}
+                    />
+                </BarChart>
+            </ResponsiveContainer>
+        </>
+    )
+}
+
+export default CounselBarChart

--- a/components/ErrorComponent.tsx
+++ b/components/ErrorComponent.tsx
@@ -1,0 +1,22 @@
+import styled from 'styled-components'
+
+const Wrapper = styled.div`
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: 0;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+`
+
+// TODO: This is an awkward name, but "Error" is a reserved word.
+// TODO: We may want to actually show some error information here.
+export const ErrorComponent = () => (
+    <Wrapper>
+        <div>An error occured.</div>
+    </Wrapper>
+)

--- a/components/FadeInSection.tsx
+++ b/components/FadeInSection.tsx
@@ -7,7 +7,7 @@ const FadeIn = styled.div<{ isVisible: boolean }>`
     transition: opacity 0.5s ${ease}, transform 0.9s ${ease};
     will-change: opacity, transform;
     opacity: 0;
-    transform: translateY(2.5vh);
+    transform: translateY(1.5vh);
 
     ${(props) => {
         if (props.isVisible) {

--- a/components/TestBarChart/index.tsx
+++ b/components/TestBarChart/index.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import {
+    BarChart,
+    Bar,
+    XAxis,
+    YAxis,
+    CartesianGrid,
+    Tooltip,
+} from 'recharts'
+
+const data = [
+    {
+        name: 'Page A',
+        uv: 4000,
+        pv: 2400,
+    },
+    {
+        name: 'Page B',
+        uv: 3000,
+        pv: 1398,
+    },
+    {
+        name: 'Page C',
+        uv: 2000,
+        pv: 9800,
+    },
+    {
+        name: 'Page D',
+        uv: 2780,
+        pv: 3908,
+    },
+    {
+        name: 'Page E',
+        uv: 1890,
+        pv: 4800,
+    },
+    {
+        name: 'Page F',
+        uv: 2390,
+        pv: 3800,
+    },
+    {
+        name: 'Page G',
+        uv: 3490,
+        pv: 4300,
+    },
+]
+
+const TestBarChart = () => {
+    return (
+        <BarChart width={730} height={250} data={data}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="name" />
+            <YAxis />
+            <Tooltip />
+            {/* <Legend /> */}
+            <Bar dataKey="pv" fill="#8884d8" />
+            <Bar dataKey="uv" fill="#82ca9d" />
+        </BarChart>
+    )
+}
+
+export default TestBarChart

--- a/lib/record.ts
+++ b/lib/record.ts
@@ -47,7 +47,10 @@ export const upsertAtMap = <A, B>(
  *
  * @example
  * const f = (k: string, n: number) => `${k.toUpperCase()}-${n}`;
- * assert.deepStrictEqual(mapWithIndex(f)({ a: 3, b: 5 }), { a: "A-3", b: "B-5" });
+ * deepStrictEqual(
+ *   mapWithIndex({ a: 3, b: 5 }, f),
+ *   { a: "A-3", b: "B-5" }
+ * );
  */
 export function mapWithIndex<A, B>(
     r: Record<string, A>,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "react-dom": "18.2.0",
         "recharts": "^2.2.0",
         "styled-components": "5.3.6",
-        "swr": "^1.3.0",
+        "swr": "^2.0.3",
         "zod": "^3.20.2"
     },
     "devDependencies": {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -20,6 +20,8 @@ import { bp } from '../lib/breakpoints'
 import { InlineLink } from '../components/Link'
 import FadeInSection from '../components/FadeInSection'
 import Spacer from '../components/Spacer'
+import { ErrorComponent } from '../components/ErrorComponent'
+import { CounselPerChargeCategoryBarChart } from '../components/CounselPerChargeCategoryBarChart/CounselPerChargeCategoryBarChart'
 
 const SECRET = process.env.NEXT_PUBLIC_COSMOSDB_SECRET
 // TODO: Update cosmos query later
@@ -62,12 +64,17 @@ const Visualizations = styled.section`
 `
 
 export default function Home() {
-    const { data: cosmosData, error: cosmosError } = useSWR(
-        `/api/cosmos?secret=${SECRET}&sql=${COSMOS_QUERY}`,
-        fetcher
-    )
+    const {
+        data: cosmosData,
+        error: cosmosError,
+        isLoading: isLoadingCosmos,
+    } = useSWR(`/api/cosmos?secret=${SECRET}&sql=${COSMOS_QUERY}`, fetcher)
 
-    const { data: repByYearsRaw, error: repByYearsErr } = useSWR(
+    const {
+        data: repByYearsRaw,
+        error: repByYearsErr,
+        isLoading: isLoadingRepsByYear,
+    } = useSWR(
         `/api/cosmos?secret=${SECRET}&sql=${REPRESENTATION_BY_YEAR_QUERY}`,
         fetcher
     )
@@ -86,9 +93,6 @@ export default function Home() {
             JSON.stringify(parsed.error.issues, null, 2)
         )
     }
-
-    const isLoading =
-        !cosmosData && !cosmosError && !repByYearsRaw && !repByYearsErr
 
     return (
         <div className={styles.container}>
@@ -142,8 +146,10 @@ export default function Home() {
                             </TextContainer>
                         </Section>
                         <Visualizations>
-                            {isLoading || !parsed.success ? (
+                            {isLoadingCosmos ? (
                                 <Loading />
+                            ) : !parsed.success ? (
+                                <ErrorComponent />
                             ) : (
                                 <div className={styles.charts}>
                                     <BarChartInteractive data={parsed.data} />
@@ -181,8 +187,10 @@ export default function Home() {
                             </TextContainer>
                         </Section>
                         <Visualizations>
-                            {isLoading || !repByYears.success ? (
+                            {isLoadingRepsByYear ? (
                                 <Loading />
+                            ) : !repByYears.success ? (
+                                <ErrorComponent />
                             ) : (
                                 <div className={styles.charts}>
                                     <BarChartYears data={repByYears.data} />
@@ -214,8 +222,10 @@ export default function Home() {
                             </TextContainer>
                         </Section>
                         <Visualizations>
-                            {isLoading || !parsed.success ? (
+                            {isLoadingCosmos ? (
                                 <Loading />
+                            ) : !parsed.success ? (
+                                <ErrorComponent />
                             ) : (
                                 <div className={styles.charts}>
                                     <StackedBarChart cases={parsed?.data} />
@@ -225,6 +235,14 @@ export default function Home() {
                     </Container>
                 </FadeInSection>
                 <Spacer />
+                <FadeInSection>
+                    <Container>
+                        <Section>
+                            <CounselPerChargeCategoryBarChart />
+                        </Section>
+                    </Container>
+                </FadeInSection>
+
                 <FadeInSection>
                     <Container>
                         <Section>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,7 +21,7 @@ import { InlineLink } from '../components/Link'
 import FadeInSection from '../components/FadeInSection'
 import Spacer from '../components/Spacer'
 import { ErrorComponent } from '../components/ErrorComponent'
-import { CounselPerChargeCategoryBarChart } from '../components/CounselPerChargeCategoryBarChart/CounselPerChargeCategoryBarChart'
+import CounselPerChargeCategoryBarChart from '../components/CounselPerChargeCategoryBarChart'
 
 const SECRET = process.env.NEXT_PUBLIC_COSMOSDB_SECRET
 // TODO: Update cosmos query later
@@ -238,8 +238,18 @@ export default function Home() {
                 <FadeInSection>
                     <Container>
                         <Section>
-                            <CounselPerChargeCategoryBarChart />
+                            <H3>
+                                What type of attorneys are represented more per charge category?
+                            </H3>
+                            <TextContainer align="left">
+                                <Paragraph>
+                                    Need copy here.
+                                </Paragraph>
+                            </TextContainer>
                         </Section>
+                        <Visualizations>
+                            <CounselPerChargeCategoryBarChart />
+                        </Visualizations>
                     </Container>
                 </FadeInSection>
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -80,3 +80,7 @@ h4 {
 .recharts-cartesian-axis .recharts-text.recharts-label tspan {
     font-size: 1rem;
 }
+
+.recharts-wrapper {
+    margin: 0 auto;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2957,10 +2957,12 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-swr@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/swr/-/swr-1.3.0.tgz#c6531866a35b4db37b38b72c45a63171faf9f4e8"
-  integrity sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==
+swr@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-2.0.3.tgz#9fe59a17f55b0fdddccd76b7b2f723f9f8e2263e"
+  integrity sha512-sGvQDok/AHEWTPfhUWXEHBVEXmgGnuahyhmRQbjl9XBYxT/MSlAzvXEKQpyM++bMPaI52vcWS2HiKNaW7+9OFw==
+  dependencies:
+    use-sync-external-store "^1.2.0"
 
 synckit@^0.8.4:
   version "0.8.4"
@@ -3065,6 +3067,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+use-sync-external-store@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 uuid@^8.3.0:
   version "8.3.2"


### PR DESCRIPTION
I mostly wanted to try recreating the `StackedBarChart` component using a SQL query; but I'm afraid I don't know the `recharts` API well enough to modify that component. Instead I just created a simple example. And the name I gave to this component is a total atrocity.. I'm sure we'll want to do a lot of refactoring.

But there were a few things I liked about this approach:

1. The data fetching and validating is all in one place
2. Preparing the data is quite a bit simpler
3. Much less data sent to the client (only around 12 small json objects)