### PR TITLE
(dep): add `@vercel/analytics`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     },
     "dependencies": {
         "@azure/cosmos": "^3.17.2",
+        "@vercel/analytics": "^0.1.8",
         "axios": "^1.2.1",
         "babel-plugin-styled-components": "2.0.7",
         "d3": "7.6.1",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,12 @@
 import '../styles/globals.css'
 import type { AppProps } from 'next/app'
+import { Analytics } from '@vercel/analytics/react'
 
 export default function App({ Component, pageProps }: AppProps) {
-    return <Component {...pageProps} />
+    return (
+        <>
+            <Component {...pageProps} />
+            <Analytics />
+        </>
+    )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -786,6 +786,11 @@
     "@typescript-eslint/types" "5.45.0"
     eslint-visitor-keys "^3.3.0"
 
+"@vercel/analytics@^0.1.8":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@vercel/analytics/-/analytics-0.1.8.tgz#71f1f8c7bb98ac0c5c47eb3fb8ccbe8141b9fe47"
+  integrity sha512-PQrOI8BJ9qUiVJuQfnKiJd15eDjDJH9TBKsNeMrtelT4NAk7d9mBVz1CoZkvoFnHQ0OW7Xnqmr1F2nScfAnznQ==
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"


### PR DESCRIPTION
In our meeting today I realized we were starting to direct people to the site, but weren't collecting any analytics data.

Vercel only offers free analytics for one deployment per account. So I turned off analytics on open-austin.org -- we might want to transfer ownership of the org site to a different vercel account.